### PR TITLE
Add swim-results-import skill (PDF → review-ready CSVs)

### DIFF
--- a/.claude/skills/swim-results-import/SKILL.md
+++ b/.claude/skills/swim-results-import/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: swim-results-import
+description: Use when extracting or importing swim meet results from a PDF or pasted meet text into CSV for the swim tracker. Team and swimmers are read from a local config (config.local.md). Produces two review-ready CSVs (Meets + Races) matching the Google Sheet schema. Handles SwimTopia Meet Maestro result exports.
+---
+
+# Swim Results Import
+
+Extract swim meet results from a PDF (or pasted meet text) into two CSV files that match
+the swim-tracker Google Sheet schema, for manual review before pasting into the Sheet.
+
+## Configuration (read this first)
+
+Real team and swimmer details live in **`config.local.md`** (co-located with this skill,
+gitignored — it holds minors' names). Before extracting, Read `config.local.md` to get:
+
+- our team's full name and its abbreviation as it appears in result rows,
+- the swimmers to extract (full names + the initials used in RaceIds),
+- the default pool size/unit,
+- any name-collision watch-outs.
+
+If `config.local.md` does not exist, tell the user to copy `config.example.md` to
+`config.local.md` and fill it in, then stop. Do not hardcode names into this file.
+
+Throughout this skill, `<OUR_TEAM>` / `<OUR_ABBR>` and "the configured swimmers" refer to
+values from that config. Extract ONLY races where a configured swimmer competed for
+`<OUR_ABBR>`, including relays they were a leg of. **Match on the full last name** — other
+swimmers may share a configured first name (see the collision notes in config).
+
+- **Output directory:** `swim-imports/` at the repo root (gitignored). Create it if missing.
+
+## Prerequisite: reading the PDF
+
+These are **SwimTopia Meet Maestro** exports. Claude's Read tool needs `poppler` to render
+PDF pages; if it's missing, extract text with layout preserved instead:
+
+```bash
+pdftotext -layout <meet>.pdf <meet>.txt   # requires: brew install poppler
+```
+
+Work from the `-layout` text. Put raw source files in `swim-imports/raw/` (also gitignored).
+
+## Meet Maestro format — parsing rules (read carefully)
+
+**Two-column layout.** `-layout` text interleaves a LEFT and RIGHT column on each line.
+Events flow down one column then the other, and **page breaks reflow the columns** — a
+single event's finishers can split across a page boundary and appear to jump columns.
+Never trust column position alone. **Anchor every swim to its event by matching the age
+group and the place sequence** (places run 1,2,3… within an event; ages fit the event's
+age group). This is the #1 source of mis-assignment — verify it.
+
+**Record-holder lines are NOT competing teams.** Each event header is followed by a record
+block like:
+
+```
+HOME    Some Name                            2025    25.52
+        Some Swim Club
+```
+
+That is the pool/league **record holder** and their club. A club that appears ONLY in
+these record blocks is NOT in the meet. (Watch for this: a club named only as a record
+holder can be mistaken for a third team — it usually isn't.)
+**Determine the competing teams solely from the team-abbreviation column in result rows**
+(your `<OUR_ABBR>` and the opponent's code). Usually that's two teams → a dual meet.
+
+**`HOME` at the END of a result row** is an achievement flag (new pool/home record), not a
+team and not a place.
+
+**Status codes in the time/place column:**
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| `DQ` | Disqualified (swam) | Include row; `DQ` in both Time and Place |
+| `NS` | No swim | Skip — no row |
+| `SCR` | Scratched | Skip — no row |
+| `X … EXH` | Exhibition (swam, doesn't score) | Include if it's a configured swimmer; `EXH` in Place, real time in Time |
+
+## Workflow
+
+1. **Read `config.local.md`** (see Configuration).
+2. **Extract the source text** (see prerequisite).
+3. **Meet date:** read it from the PDF header (e.g. "— Jun 10, 2026" / "06/10/2026"). Use
+   the actual race date, NOT today's date and NOT the download date in the filename.
+4. **Competing teams & opponent:** from result-row team abbreviations only (ignore record
+   blocks). Opponent = the team that isn't `<OUR_ABBR>`. For a true 3+-team meet, set
+   `NumTeams`; for a dual meet leave `TeamPlace`/`NumTeams` blank.
+5. **Location:** `Away` if the meet name is "<OUR_TEAM> at <host>"; `Home` if hosted by
+   `<OUR_TEAM>`; else blank. Capitalized (`Home`/`Away`), not lowercase.
+6. **Score:** Meet Maestro individual-results exports usually have NO team score — leave
+   `OurPoints`/`TheirPoints` blank (do not invent zeros). Only fill if a score is printed.
+7. **Scan every event** for the configured swimmers on `<OUR_ABBR>`, including relays.
+8. **Write the two CSVs**, run the verification pass, print the summary.
+
+## Naming: use team abbreviations, not full names
+
+Use the team codes from the results' team column (ours is `<OUR_ABBR>`; the opponent's is
+their own short code, e.g. `<OPP_ABBR>`). Full names appear ONLY in the `Opponent` column.
+
+- `MeetId` = date + host-ordered team codes (lowercase): away → `<date>-<ours>-<opp>`;
+  home → `<date>-<opp>-<ours>`.
+- `MeetName` = `<OUR_ABBR> @ <OPP-ABBR> <year>` for an away meet, or
+  `<OPP-ABBR> @ <OUR_ABBR> <year>` for a home meet. `@` marks the host's pool.
+- Output filenames mirror the MeetId: `<MeetId>-meets.csv` and `<MeetId>-races.csv`.
+
+## Output files
+
+`swim-imports/<MeetId>-meets.csv` and `swim-imports/<MeetId>-races.csv`.
+
+### Meets CSV — exactly one row
+
+```
+MeetId,Date,MeetName,Opponent,Location,PoolSize,PoolUnit,OurPoints,TheirPoints,TeamPlace,NumTeams
+```
+- `MeetId` / `MeetName` per the naming section above (abbreviations).
+- `Date` = `YYYY-MM-DD` (from the PDF)
+- `Opponent` = opponent's FULL name
+- `PoolSize`/`PoolUnit` = the config default unless the PDF indicates otherwise
+- `OurPoints`/`TheirPoints` = blank if no score; `TeamPlace`/`NumTeams` = blank for a dual
+
+### Races CSV — one row per swimmer's swim
+
+```
+RaceId,MeetId,Swimmer,EventNumber,AgeGroup,Distance,Stroke,Time,Place,NumSwimmers
+```
+- `RaceId` = `<date>-<event#>-<initials>`, where `<event#>` is the `#NN` event number from
+  the PDF and `<initials>` are the configured first+last initials (e.g. a swimmer "Jordan
+  Lee" → `jl`). Event# + initials is already unique, so relays need no suffix; when two
+  configured swimmers share a relay, write one row each.
+- `Swimmer` = first name only.
+- `AgeGroup` from the event header (e.g. `8 & Under`); `Distance` in the pool unit;
+  `EventNumber` from the `#NN` header.
+- `Time` = `SS.SS` or `M:SS.SS`; use the Official (final) time, two decimals.
+- `Place` = the swimmer's finishing place; `NumSwimmers` = number of ranked finishers in
+  that event (the highest place number). For relays: number of ranked relay teams.
+- `DQ` → `DQ` in both Time and Place. Exhibition → `EXH` in Place.
+
+## Normalization
+
+| Source | Write as |
+|--------|----------|
+| Free | Freestyle |
+| Back | Backstroke |
+| Breast | Breaststroke |
+| Fly | Butterfly |
+| IM / I.M. | IM |
+| Medley/Free Relay | `Medley Relay` / `Freestyle Relay` (Stroke), relay distance in Distance |
+| `38.7`, `1:05.32` | `38.70`, `1:05.32` (two decimals) |
+
+## Verification pass (before printing the summary)
+
+1. Re-scan the source for EVERY occurrence of each configured swimmer's last name
+   (`grep -n "<Lastname>"`); reconcile the count against your rows. Relay legs list names as
+   `1) Lastname, First (8)` — don't miss a swimmer buried in a relay.
+2. For each swim, confirm the event assignment via age group + place order (page-reflow trap).
+3. Spot-check several times and places against the source.
+4. Confirm every Races `MeetId` equals the single Meets `MeetId`, and column counts match
+   (Meets = 11, Races = 10).
+
+## Final summary (print to the user)
+
+```
+Meet: <date> vs <Opponent> (<home/away>) — <score or "score not in this PDF">
+  <Swimmer>: #35 25 Breaststroke, 36.25, 4 of 6
+  ...
+Wrote: swim-imports/<MeetId>-meets.csv
+       swim-imports/<MeetId>-races.csv
+```
+
+Flag any judgment calls (date source, pool size, multi-team opponent) for the user, and
+remind them to review the CSVs before pasting into the Google Sheet.
+
+## Common mistakes
+
+- Counting a record-holder's club (in the `HOME … / Club` block) as a competing team.
+- Mis-assigning a swim to the wrong event after a page-break column reflow.
+- Using the filename/download date instead of the meet date in the PDF header.
+- Inventing `0–0` when no score is printed.
+- Grabbing a swimmer who shares a configured first name (match the full last name), or
+  another team's swimmer.
+- Missing a swimmer's leg inside a relay.

--- a/.claude/skills/swim-results-import/config.example.md
+++ b/.claude/skills/swim-results-import/config.example.md
@@ -1,0 +1,34 @@
+# Swim Results Import — config template
+
+Copy this file to `config.local.md` (which is gitignored) and fill in your real team and
+swimmer details. The skill reads `config.local.md` at runtime; if it's missing, the skill
+will ask you to create it from this template.
+
+Keep real swimmer names only in `config.local.md` — never in committed files.
+
+## Our team
+
+- **Name (full):** <Your Team Name>
+- **Abbreviation (as it appears in result rows' team column):** <ABBR>
+
+## Swimmers to extract
+
+Extract only races where one of these swimmers competed for our team (include relays they
+were a leg of). Match on the full last name.
+
+| First | Last | Initials (for RaceId) |
+|-------|------|-----------------------|
+| <First> | <Last> | <fl> |
+| <First> | <Last> | <fl> |
+
+## Pool default
+
+- **PoolSize:** <e.g. 25>
+- **PoolUnit:** <meters or yards>
+
+## Name-collision watch-outs
+
+List any other swimmers in your league who share a first name with one of yours, so the
+skill matches the full last name and doesn't grab the wrong kid. (Optional.)
+
+- <e.g. "Firstname Otherlast" — different swimmer>

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ pids
 *.pid
 *.seed
 *.pid.lock
+
+# Swim meet imports (real-name results — never commit, see swim-tracker privacy gating)
+swim-imports/
+
+# Personal swim-import skill config (real swimmer/team names — never commit)
+.claude/skills/swim-results-import/config.local.md

--- a/docs/superpowers/specs/2026-06-13-swim-results-import-skill-design.md
+++ b/docs/superpowers/specs/2026-06-13-swim-results-import-skill-design.md
@@ -1,0 +1,102 @@
+# Swim Results Import Skill — Design
+
+**Date:** 2026-06-13
+**Status:** Approved
+
+## Purpose
+
+Turn the existing manual PDF-extraction workflow (`src/routes/swim-tracker/PDF_IMPORT_TEMPLATE.md`)
+into a reusable, auto-invoked Claude skill. The team and swimmers to track are read from a
+gitignored local config (`config.local.md`) so no personal data lives in the committed
+skill. Given a swim meet results PDF (or pasted meet text), the skill extracts the meet
+metadata and the configured swimmers' race results into two CSV files matching the
+existing Google Sheet schema, for manual review before pasting into the Sheet.
+
+Out of scope: writing directly to Google Sheets (future automation).
+
+## Skill Identity
+
+- **Name:** `swim-results-import`
+- **Location:** `.claude/skills/swim-results-import/SKILL.md` (project skill, checked in)
+- **Trigger / description:** when the user wants to extract or import swim meet results
+  from a PDF (or pasted meet text) into CSV for the swim tracker.
+
+## Approach
+
+Pure instructional skill (no helper script). PDF extraction is fundamentally a
+reading/vision task, so the failure mode that matters — misreading a time or place, or
+missing a race — is an *extraction* error that a format-validation script cannot catch.
+That risk is addressed by a strong in-skill verification pass instead. Format
+consistency (column order, time format, ID linkage) is guaranteed by being explicit in
+the instructions. This keeps the skill a zero-dependency single file.
+
+## Configuration (no PII in the repo)
+
+Team and swimmer specifics are read at runtime from `config.local.md` (co-located with the
+skill, gitignored). A committed `config.example.md` documents the format. The config holds:
+our team's full name + abbreviation, the swimmers to extract (full names + RaceId initials),
+the default pool size/unit, and name-collision watch-outs. The committed `SKILL.md` uses
+placeholders only — minors' names never enter version control.
+
+- **Output directory:** `swim-imports/` at repo root (created if missing, gitignored so
+  real-name results are never committed — consistent with the repo's existing privacy gating).
+
+## Output
+
+Two CSV files per meet:
+
+1. `swim-imports/<date>-<opponent-slug>-meets.csv` — one row.
+   Columns: `MeetId,Date,MeetName,Opponent,Location,PoolSize,PoolUnit,OurPoints,TheirPoints,TeamPlace,NumTeams`
+2. `swim-imports/<date>-<opponent-slug>-races.csv` — one row per kid's swim.
+   Columns: `RaceId,MeetId,Swimmer,EventNumber,AgeGroup,Distance,Stroke,Time,Place,NumSwimmers`
+
+`<date>` is `YYYY-MM-DD`; `<opponent-slug>` is the opponent name lowercased and
+hyphenated.
+
+## Extraction Rules
+
+- **Date** comes from the PDF (the actual race date), NOT today's date. (This fixes a
+  bug in the current `PDF_IMPORT_TEMPLATE.md`, which says to use today's date.)
+- **MeetId** = `YYYY-MM-DD-<opponent-slug>`.
+- **RaceId** = `YYYY-MM-DD-<event#>-<swimmer-initial>` (Q/M/E). For relays, append a
+  short suffix so IDs stay unique (e.g. `-relay`).
+- **Swimmer** column uses first name only (single family tracked); match the full last
+  name from config to avoid grabbing a different swimmer who shares a first name.
+- **Strokes** normalized to full names: Free→Freestyle, Back→Backstroke,
+  Breast→Breaststroke, Fly→Butterfly, IM→IM.
+- **Times** normalized to `SS.SS` (under a minute) or `M:SS.SS` (a minute or more).
+  Strip reaction-time prefixes; use final swim time only.
+- **DQ:** put `DQ` in both Time and Place.
+- **Missing meet score:** leave `OurPoints` and `TheirPoints` blank — do not invent
+  zeros.
+- **Location:** `home` or `away` if determinable from the PDF, else blank.
+- **Optional fields** (TeamPlace, NumTeams) for dual meets: blank when not applicable.
+- Any other unknown field: leave blank rather than guess.
+
+## Verification Pass (before finishing)
+
+1. Re-scan the PDF for every event; confirm no configured swimmer's race was missed —
+   especially multi-swimmer heats and relays where a swimmer's name may be one of several.
+2. Spot-check a sample of times and places against the source text.
+3. Confirm every Races row's `MeetId` matches the single Meets row's `MeetId`.
+4. Confirm column counts and order match the schema exactly.
+
+## User-Facing Output
+
+After writing the two files, print a compact summary so the user can eyeball it before
+pasting into the Sheet:
+
+- Meet line: date, opponent, score (or "score not found").
+- Per-kid race list: event, distance + stroke, time, place.
+- The two output file paths.
+
+## Testing
+
+Dry-run the finished skill against a sample meet text block (covering an individual
+swim, a relay, a DQ, and a missing-score case) to confirm it produces two
+correctly-shaped CSV files and a sensible summary.
+
+## Deviations Allowed (defaulted, user-overridable)
+
+- Filename pattern `<date>-<opponent>-meets.csv` / `-races.csv`.
+- Blank (not `0`) score when not found.


### PR DESCRIPTION
## Summary
Adds a Claude skill, `swim-results-import`, that extracts swim meet results from **SwimTopia Meet Maestro** PDF exports into two CSVs (Meets + Races) matching the existing swim-tracker Google Sheet schema, for manual review before pasting into the Sheet.

The skill encodes what was learned running it on a real meet: the two-column / page-reflow layout, record-holder lines that must not be counted as teams, status codes (DQ/NS/SCR/EXH), meet-date-from-PDF (not filename), and the Meet/Race CSV schema + naming conventions (MeetId, RaceId).

## Privacy
This repo is public, so no personal data is committed:
- Team + swimmer details (including minors' names) are read at runtime from a **gitignored** `config.local.md`.
- The committed `SKILL.md` and `config.example.md` contain **placeholders only**.
- Generated CSVs and raw PDFs live under the gitignored `swim-imports/`.

## Files
- `.claude/skills/swim-results-import/SKILL.md` — the skill (placeholders, reads config)
- `.claude/skills/swim-results-import/config.example.md` — config template
- `docs/superpowers/specs/2026-06-13-swim-results-import-skill-design.md` — design spec (de-identified)
- `.gitignore` — ignore `config.local.md` and `swim-imports/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)